### PR TITLE
FEAT: Frontend page for viewing a single event

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import './App.css';
 import useEvents from './hooks/useEvents';
 import EventPage from './pages/eventPage/EventPage';
+import EventsPage from './pages/eventsPage/EventsPage';
 
 function App() {
 
@@ -11,7 +12,8 @@ function App() {
   return (
     <div className="app">
       <Routes>
-        <Route path="events" element={ <EventPage events={events} isFetching={isFetching} isFetched={isFetched} fetchError={fetchError} /> } />
+        <Route path="events" element={ <EventsPage events={events} isFetching={isFetching} isFetched={isFetched} fetchError={fetchError} /> } />
+        <Route path="event/:eventID" element={ <EventPage events={events} isFetchingEvents={isFetching} fetchError={fetchError} /> } />
         <Route path="*" element={ <Navigate to="events" /> } />
       </Routes>
     </div>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -5,6 +5,7 @@ import mockEvents from './consts/mockEvents';
 
 beforeEach(() => {
   fetch.resetMocks();
+  jest.resetAllMocks();
 })
 
 test("navigates to events", () => {

--- a/frontend/src/hooks/useEvents.jsx
+++ b/frontend/src/hooks/useEvents.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 function useEvents() {
 
-  const [events, setEvents] = React.useState();
+  const [events, setEvents] = React.useState([]);
   const [isFetching, setIsFetching] = React.useState(false);
   const [isFetched, setIsFetched] = React.useState(false);
   const [error, setError] = React.useState();

--- a/frontend/src/pages/eventPage/EventPage.jsx
+++ b/frontend/src/pages/eventPage/EventPage.jsx
@@ -1,53 +1,34 @@
 import React from 'react'
+import { useParams } from 'react-router-dom'
 
-const columns = [
-  {
-    header: "Name",
-    accessor: "name"
-  },
-  {
-    header: "Type",
-    accessor: "type"
-  }
-];
+function EventPage({ events, isFetchingEvents, fetchError }) {
 
-function EventPage({ events, isFetching, fetchError }) {
+  const eventID = useParams().eventID;
+  const event = !events ? null : events.find((event) => event.id === eventID);
 
-  function renderEvents() {
-    if(isFetching) {
-      return (
-        <p>Fetching</p>
-      );
+  function renderContent() {
+    if(isFetchingEvents) {
+      return <p>fetching</p>
     }
 
     if(fetchError) {
       return <p>{fetchError}</p>
     }
 
-    if(events.length === 0) {
+    if(!event) {
       return (
-        <p>No data</p>
+        <p>The event could not be found</p>
       );
     }
 
     return (
-      <table>
-        <thead>
-          <tr>
-            { columns.map((column) => <th key={column.accessor}>{column.header}</th>) }
-          </tr>
-        </thead>
-        <tbody>
-          { events.map(event => <tr key={event.id}>
-            { columns.map((column) => <td key={column.accessor}>{event[column.accessor]}</td>) }
-          </tr>) }
-        </tbody>
-      </table>
+      <p>{event.name}</p>
     );
   }
+
   return (
-    <div className="event-page">
-      { renderEvents() }
+    <div>
+      { renderContent() }
     </div>
   )
 }

--- a/frontend/src/pages/eventPage/EventPage.test.js
+++ b/frontend/src/pages/eventPage/EventPage.test.js
@@ -1,23 +1,39 @@
 import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
 import EventPage from "./EventPage";
 
-test("renders fetching when fetching", () => {
-  render(<EventPage isFetching={true}/>);
-  expect(screen.getByText("Fetching")).toBeInTheDocument();
+beforeEach(() => {
+  jest.clearAllMocks();
 });
 
-test("renders no data when no data", () => {
-  render(<EventPage events={[]} />);
-  expect(screen.getByText("No data")).toBeInTheDocument();
+afterEach(() => {
+  jest.clearAllMocks();
 });
 
-test("renders name of event", () => {
-  render(<EventPage events={[ { name: "myNameIsHere", type: "myTypeIsHere" } ]} />);
-  expect(screen.getByText("myNameIsHere")).toBeInTheDocument();
+function mockUseParamsWithEventID(mockEventID) {
+  jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+      eventID: mockEventID
+    }),
+    //useRouteMatch: () => ({ url: "/event/eventID" })
+  }));
+}
+
+test("renders fetching if fetching", () => {
+  mockUseParamsWithEventID("abc");
+  render(<EventPage isFetchingEvents={true} />);
+  expect(screen.getByText("fetching")).toBeInTheDocument();
 });
 
-test("renders type of event", () => {
-  render(<EventPage events={[ { name: "myNameIsHere", type: "myTypeIsHere" } ]} />);
-  expect(screen.getByText("myTypeIsHere")).toBeInTheDocument();
+test("renders error if error", () => {
+  mockUseParamsWithEventID("abc");
+  render(<EventPage isFetchingEvents={false} fetchError={"could not fetch"} />);
+  expect(screen.getByText("could not fetch")).toBeInTheDocument();
 });
 
+test("renders could not be found if could not be found", () => {
+  mockUseParamsWithEventID("abc");
+  render(<EventPage events={ [] } isFetchingEvents={false} fetchError={null} />);
+  expect(screen.getByText("The event could not be found")).toBeInTheDocument();
+});

--- a/frontend/src/pages/eventsPage/EventsPage.jsx
+++ b/frontend/src/pages/eventsPage/EventsPage.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+const columns = [
+  {
+    header: "Name",
+    accessor: "name"
+  },
+  {
+    header: "Type",
+    accessor: "type"
+  }
+];
+
+function EventsPage({ events, isFetching, fetchError }) {
+
+  function renderEvents() {
+    if(isFetching) {
+      return (
+        <p>Fetching</p>
+      );
+    }
+
+    if(fetchError) {
+      return <p>{fetchError}</p>
+    }
+
+    if(events.length === 0) {
+      return (
+        <p>No data</p>
+      );
+    }
+
+    return (
+      <table>
+        <thead>
+          <tr>
+            { columns.map((column) => <th key={column.accessor}>{column.header}</th>) }
+          </tr>
+        </thead>
+        <tbody>
+          { events.map(event => <tr key={event.id}>
+            { columns.map((column) => <td key={column.accessor}>{event[column.accessor]}</td>) }
+          </tr>) }
+        </tbody>
+      </table>
+    );
+  }
+  return (
+    <div className="event-page">
+      { renderEvents() }
+    </div>
+  )
+}
+
+export default EventsPage

--- a/frontend/src/pages/eventsPage/EventsPage.test.js
+++ b/frontend/src/pages/eventsPage/EventsPage.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import EventsPage from "./EventsPage";
+
+test("renders fetching when fetching", () => {
+  render(<EventsPage isFetching={true}/>);
+  expect(screen.getByText("Fetching")).toBeInTheDocument();
+});
+
+test("renders no data when no data", () => {
+  render(<EventsPage events={[]} />);
+  expect(screen.getByText("No data")).toBeInTheDocument();
+});
+
+test("renders name of event", () => {
+  render(<EventsPage events={[ { id: "abc", name: "myNameIsHere", type: "myTypeIsHere" } ]} />);
+  expect(screen.getByText("myNameIsHere")).toBeInTheDocument();
+});
+
+test("renders type of event", () => {
+  render(<EventsPage events={[ { id: "abc", name: "myNameIsHere", type: "myTypeIsHere" } ]} />);
+  expect(screen.getByText("myTypeIsHere")).toBeInTheDocument();
+});
+


### PR DESCRIPTION
Added a page and route on the frontend where you can view a single event, given by its event id. #32